### PR TITLE
fix(RHOAIENG-26139): Bump transformers from 4.47.0 to 4.48.0

### DIFF
--- a/detectors/huggingface/requirements.txt
+++ b/detectors/huggingface/requirements.txt
@@ -1,1 +1,1 @@
-transformers==4.47.0
+transformers==4.48.0


### PR DESCRIPTION
Refer to [RHOAIENG-26139](https://issues.redhat.com/browse/RHOAIENG-26139).