### PR TITLE
Migrate llm-judge detector to TrustyAI

### DIFF
--- a/.github/workflows/build-and-push-judge.yaml
+++ b/.github/workflows/build-and-push-judge.yaml
@@ -1,0 +1,122 @@
+name: Build and Push - LLM Judge Detector
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - v*
+    paths:
+      - 'detectors/llm_judge/*'
+      - 'detectors/Dockerfile.judge'
+  pull_request_target:
+    paths:
+      - 'detectors/llm_judge/*'
+      - 'detectors/Dockerfile.judge'
+    types: [labeled, opened, synchronize, reopened]
+jobs:
+  # Ensure that tests pass before publishing a new image.
+  build-and-push-ci:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+      security-events: write
+    steps: # Assign context variable for various action contexts (tag, main, CI)
+      - name: Assigning CI context
+        if: github.head_ref != '' && github.head_ref != 'main' && !startsWith(github.ref, 'refs/tags/v')
+        run: echo "BUILD_CONTEXT=ci" >> $GITHUB_ENV
+      - name: Assigning tag context
+        if: github.head_ref == '' && startsWith(github.ref, 'refs/tags/v')
+        run: echo "BUILD_CONTEXT=tag" >> $GITHUB_ENV
+      - name: Assigning main context
+        if: github.head_ref == '' && github.ref == 'refs/heads/main'
+        run: echo "BUILD_CONTEXT=main" >> $GITHUB_ENV
+      #
+      # Run checkouts
+      - uses: mheap/github-action-required-labels@v4
+        if: env.BUILD_CONTEXT == 'ci'
+        with:
+          mode: minimum
+          count: 1
+          labels: "ok-to-test, lgtm, approved"
+      - uses: actions/checkout@v3
+        if: env.BUILD_CONTEXT == 'ci'
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - uses: actions/checkout@v3
+        if: env.BUILD_CONTEXT == 'main' ||  env.BUILD_CONTEXT == 'tag'
+      #
+      # Print variables for debugging
+      - name: Log reference variables
+        run: |
+          echo "CONTEXT: ${{ env.BUILD_CONTEXT }}"
+          echo "GITHUB.REF: ${{ github.ref }}"
+          echo "GITHUB.HEAD_REF: ${{ github.head_ref }}"
+          echo "SHA: ${{ github.event.pull_request.head.sha }}"
+          echo "MAIN IMAGE AT: quay.io/trustyai/guardrails-detector-llm-judge:latest"
+          echo "CI IMAGE AT: quay.io/trustyai/guardrails-detector-llm-judge-ci:${{ github.event.pull_request.head.sha }}"
+
+      # Set environments depending on context
+      - name: Set CI environment
+        if:  env.BUILD_CONTEXT == 'ci'
+        run: |
+          echo "TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
+          echo "IMAGE_NAME=quay.io/trustyai/guardrails-detector-llm-judge-ci" >> $GITHUB_ENV
+      - name: Set main-branch environment
+        if:  env.BUILD_CONTEXT == 'main'
+        run: |
+          echo "TAG=latest" >> $GITHUB_ENV
+          echo "IMAGE_NAME=quay.io/trustyai/guardrails-detector-llm-judge" >> $GITHUB_ENV
+      - name: Set tag environment
+        if: env.BUILD_CONTEXT == 'tag'
+        run: |
+          echo "TAG=${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "IMAGE_NAME=quay.io/trustyai/guardrails-detector-llm-judge" >> $GITHUB_ENV
+      #
+      # Run docker commands
+      - name: Put expiry date on CI-tagged image
+        if:  env.BUILD_CONTEXT == 'ci'
+        run: echo 'LABEL quay.expires-after=7d#' >> detectors/Dockerfile.judge
+      - name: Build image
+        run: docker build -t ${{ env.IMAGE_NAME }}:$TAG -f detectors/Dockerfile.judge detectors
+      - name: Log in to Quay
+        run: docker login -u ${{ secrets.QUAY_ROBOT_USERNAME }} -p ${{ secrets.QUAY_ROBOT_SECRET }} quay.io
+      - name: Push to Quay CI repo
+        run: docker push ${{ env.IMAGE_NAME }}:$TAG
+
+      # Leave comment
+      - uses: peter-evans/find-comment@v3
+        name: Find Comment
+        if:  env.BUILD_CONTEXT == 'ci'
+        id: fc
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes:  PR image build completed successfully
+      - uses: peter-evans/create-or-update-comment@v4
+        if:  env.BUILD_CONTEXT == 'ci'
+        name: Generate/update success message comment
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: |
+            PR image build completed successfully!
+            
+            📦 [PR image](https://quay.io/repository/trustyai/guardrails-detector-llm-judge-ci?tab=tags): `quay.io/trustyai/guardrails-detector-llm-judge-ci:${{ github.event.pull_request.head.sha }}`
+      - name: Trivy scan
+        uses: aquasecurity/trivy-action@0.28.0
+        with:
+          scan-type: 'image'
+          image-ref: "${{ env.IMAGE_NAME }}:${{ env.TAG }}"
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'MEDIUM,HIGH,CRITICAL'
+          exit-code: '0'
+          ignore-unfixed: false
+          vuln-type: 'os,library'
+
+      - name: Update Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: 'trivy-results.sarif'

--- a/detectors/llm_judge/deploy/servingruntime.yaml
+++ b/detectors/llm_judge/deploy/servingruntime.yaml
@@ -17,7 +17,7 @@ spec:
       name: guardrails-detector-llm-judge
   containers:
     - name: kserve-container
-      image: quay.io/spandraj/guardrails-detector-judge:latest
+      image: quay.io/trustyai/guardrails-detector-llm-judge:latest
       command:
         - uvicorn
         - detectors.llm_judge.app:app


### PR DESCRIPTION
Migrates the LLM judge detector to official TrustyAI registry and adds automated image build pipeline.

### Changes
- Added `build-and-push-judge.yaml` workflow (adapted from existing HF build & push)
- Updated `servingruntime.yaml` to use `quay.io/trustyai/guardrails-detector-llm-judge:latest`


#### Solves - #15 