### PR TITLE
Update and rename build-and-push-hf.yaml to build-and-push.yaml, broaden change triggers

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -1,4 +1,4 @@
-name: Build and Push - Huggingface Detector
+name: Build and Push - Detectors
 on:
   push:
     branches:
@@ -6,12 +6,11 @@ on:
     tags:
       - v*
     paths:
-      - 'detectors/huggingface/*'
-      - 'detectors/Dockerfile.hf'
+      - 'detectors/*'
+      - '.github/workflows/*'
   pull_request_target:
     paths:
-      - 'detectors/huggingface/*'
-      - 'detectors/Dockerfile.hf'
+      - 'detectors/*'
     types: [labeled, opened, synchronize, reopened]
 jobs:
   # Ensure that tests pass before publishing a new image.


### PR DESCRIPTION
## Summary by Sourcery

Rename and broaden the GitHub Actions build-and-push workflow to cover all detectors and workflow modifications

Build:
- Rename .github/workflows/build-and-push-hf.yaml to build-and-push.yaml and update workflow name to Build and Push - Detectors
- Expand push and pull_request_target path filters to include detectors/* and .github/workflows/*