### PR TITLE
CI: Fix security scan upload

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -136,11 +136,13 @@ jobs:
           exit-code: '0'
           ignore-unfixed: false
           vuln-type: 'os,library'
-      - name: Update Security tab
+      - name: Update Security tab - Huggingface
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results.sarif'
-      - name: Update Security tab
+          category: huggingface
+      - name: Update Security tab - Built-in
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: 'trivy-results-built-in.sarif'
+          category: built-in


### PR DESCRIPTION
Security scan uploads were failing due to repeated usages of the job- need to specify different categories of scan to resolve this.

## Summary by Sourcery

Fix CI security scan upload failures by specifying separate categories for each SARIF report

Bug Fixes:
- Resolve failing security scan uploads by adding 'huggingface' and 'built-in' categories

CI:
- Add category fields to GitHub codeql-action SARIF upload steps for distinct scans