### PR TITLE
Change built-in dockerfile for backwards compatibility with legacy built-in detectors

### DIFF
--- a/detectors/Dockerfile.builtIn
+++ b/detectors/Dockerfile.builtIn
@@ -23,4 +23,10 @@ COPY ./common /app/detectors/common
 COPY ./built_in/* /app
 
 EXPOSE 8080
-CMD ["uvicorn", "app:app", "--workers", "4", "--host", "0.0.0.0", "--port", "8080", "--log-config", "/app/detectors/common/log_conf.yaml"]
+
+# for backwards compatibility with existing k8s deployment configs
+RUN mkdir /app/bin &&\
+     echo '#!/bin/bash' > /app/bin/regex-detector &&\
+    echo "uvicorn app:app --workers 4 --host 0.0.0.0 --port 8080 --log-config /app/detectors/common/log_conf.yaml" >> /app/bin/regex-detector &&\
+    chmod +x /app/bin/regex-detector
+CMD ["/app/bin/regex-detector"]


### PR DESCRIPTION
This makes sure that the existing k8s deployment config can successfully launch the new python server,

## Summary by Sourcery

Enhancements:
- Update the built-in Detector Dockerfile to support launching the new Python server while preserving backward compatibility with legacy detectors