### PR TITLE
Rename pushed builtIn image for consistency

### DIFF
--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -54,7 +54,7 @@ jobs:
           echo "SHA: ${{ github.event.pull_request.head.sha }}"
           echo "MAIN IMAGE AT: ${{ vars.QUAY_RELEASE_REPO }}:latest"
           echo "CI IMAGE AT: quay.io/trustyai/guardrails-detector-huggingface-runtime-ci:${{ github.event.pull_request.head.sha }}"
-          echo "Built-In Detector CI IMAGE AT: quay.io/trustyai/builtin-detector-ci:${{ github.event.pull_request.head.sha }}"
+          echo "Built-In Detector CI IMAGE AT: quay.io/trustyai/guardrails-builtin-detector-ci:${{ github.event.pull_request.head.sha }}"
 
       # Set environments depending on context
       - name: Set CI environment
@@ -62,19 +62,19 @@ jobs:
         run: |
           echo "TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
           echo "IMAGE_NAME=quay.io/trustyai/guardrails-detector-huggingface-runtime-ci" >> $GITHUB_ENV
-          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/builtin-detector-ci" >> $GITHUB_ENV
+          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-builtin-detector-ci" >> $GITHUB_ENV
       - name: Set main-branch environment
         if:  env.BUILD_CONTEXT == 'main'
         run: |
           echo "TAG=latest" >> $GITHUB_ENV
           echo "IMAGE_NAME=${{ vars.QUAY_RELEASE_REPO }}" >> $GITHUB_ENV
-          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/builtin-detector" >> $GITHUB_ENV
+          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-builtin-detector" >> $GITHUB_ENV
       - name: Set tag environment
         if: env.BUILD_CONTEXT == 'tag'
         run: |
           echo "TAG=${{ github.ref_name }}" >> $GITHUB_ENV
           echo "IMAGE_NAME=${{ vars.QUAY_RELEASE_REPO }}" >> $GITHUB_ENV
-          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/builtin-detector" >> $GITHUB_ENV
+          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-builtin-detector" >> $GITHUB_ENV
       #
       # Run docker commands
       - name: Put expiry date on CI-tagged image
@@ -113,7 +113,7 @@ jobs:
             PR image build completed successfully!
             
             📦 [PR image](https://quay.io/repository/trustyai/guardrails-detector-huggingface-runtime-ci?tab=tags): `quay.io/trustyai/guardrails-detector-huggingface-runtime-ci:${{ github.event.pull_request.head.sha }}`
-            📦 [PR image](https://quay.io/trustyai/builtin-detector-ci?tab=tags): `quay.io/trustyai/builtin-detector-ci:${{ github.event.pull_request.head.sha }}`
+            📦 [PR image](https://quay.io/trustyai/guardrails-builtin-detector-ci?tab=tags): `quay.io/trustyai/guardrails-builtin-detector-ci:${{ github.event.pull_request.head.sha }}`
       - name: Trivy scan
         uses: aquasecurity/trivy-action@0.28.0
         with:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -54,7 +54,7 @@ jobs:
           echo "SHA: ${{ github.event.pull_request.head.sha }}"
           echo "MAIN IMAGE AT: ${{ vars.QUAY_RELEASE_REPO }}:latest"
           echo "CI IMAGE AT: quay.io/trustyai/guardrails-detector-huggingface-runtime-ci:${{ github.event.pull_request.head.sha }}"
-          echo "Built-In Detector CI IMAGE AT: quay.io/trustyai/guardrails-detector-builtin-ci:${{ github.event.pull_request.head.sha }}"
+          echo "Built-In Detector CI IMAGE AT: quay.io/trustyai/guardrails-detector-built-in-ci:${{ github.event.pull_request.head.sha }}"
 
       # Set environments depending on context
       - name: Set CI environment
@@ -62,19 +62,19 @@ jobs:
         run: |
           echo "TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
           echo "IMAGE_NAME=quay.io/trustyai/guardrails-detector-huggingface-runtime-ci" >> $GITHUB_ENV
-          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-detector-builtin-ci" >> $GITHUB_ENV
+          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-detector-built-in-ci" >> $GITHUB_ENV
       - name: Set main-branch environment
         if:  env.BUILD_CONTEXT == 'main'
         run: |
           echo "TAG=latest" >> $GITHUB_ENV
           echo "IMAGE_NAME=${{ vars.QUAY_RELEASE_REPO }}" >> $GITHUB_ENV
-          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-detector-builtin" >> $GITHUB_ENV
+          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-detector-built-in" >> $GITHUB_ENV
       - name: Set tag environment
         if: env.BUILD_CONTEXT == 'tag'
         run: |
           echo "TAG=${{ github.ref_name }}" >> $GITHUB_ENV
           echo "IMAGE_NAME=${{ vars.QUAY_RELEASE_REPO }}" >> $GITHUB_ENV
-          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-detector-builtin" >> $GITHUB_ENV
+          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-detector-built-in" >> $GITHUB_ENV
       #
       # Run docker commands
       - name: Put expiry date on CI-tagged image
@@ -113,7 +113,7 @@ jobs:
             PR image build completed successfully!
             
             📦 [PR image](https://quay.io/repository/trustyai/guardrails-detector-huggingface-runtime-ci?tab=tags): `quay.io/trustyai/guardrails-detector-huggingface-runtime-ci:${{ github.event.pull_request.head.sha }}`
-            📦 [PR image](https://quay.io/trustyai/guardrails-detector-builtin?tab=tags): `quay.io/trustyai/guardrails-detector-builtin-ci:${{ github.event.pull_request.head.sha }}`
+            📦 [PR image](https://quay.io/trustyai/guardrails-detector-built-in-ci?tab=tags): `quay.io/trustyai/guardrails-detector-built-in-ci:${{ github.event.pull_request.head.sha }}`
       - name: Trivy scan
         uses: aquasecurity/trivy-action@0.28.0
         with:

--- a/.github/workflows/build-and-push.yaml
+++ b/.github/workflows/build-and-push.yaml
@@ -54,7 +54,7 @@ jobs:
           echo "SHA: ${{ github.event.pull_request.head.sha }}"
           echo "MAIN IMAGE AT: ${{ vars.QUAY_RELEASE_REPO }}:latest"
           echo "CI IMAGE AT: quay.io/trustyai/guardrails-detector-huggingface-runtime-ci:${{ github.event.pull_request.head.sha }}"
-          echo "Built-In Detector CI IMAGE AT: quay.io/trustyai/guardrails-builtin-detector-ci:${{ github.event.pull_request.head.sha }}"
+          echo "Built-In Detector CI IMAGE AT: quay.io/trustyai/guardrails-detector-builtin-ci:${{ github.event.pull_request.head.sha }}"
 
       # Set environments depending on context
       - name: Set CI environment
@@ -62,19 +62,19 @@ jobs:
         run: |
           echo "TAG=${{ github.event.pull_request.head.sha }}" >> $GITHUB_ENV
           echo "IMAGE_NAME=quay.io/trustyai/guardrails-detector-huggingface-runtime-ci" >> $GITHUB_ENV
-          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-builtin-detector-ci" >> $GITHUB_ENV
+          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-detector-builtin-ci" >> $GITHUB_ENV
       - name: Set main-branch environment
         if:  env.BUILD_CONTEXT == 'main'
         run: |
           echo "TAG=latest" >> $GITHUB_ENV
           echo "IMAGE_NAME=${{ vars.QUAY_RELEASE_REPO }}" >> $GITHUB_ENV
-          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-builtin-detector" >> $GITHUB_ENV
+          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-detector-builtin" >> $GITHUB_ENV
       - name: Set tag environment
         if: env.BUILD_CONTEXT == 'tag'
         run: |
           echo "TAG=${{ github.ref_name }}" >> $GITHUB_ENV
           echo "IMAGE_NAME=${{ vars.QUAY_RELEASE_REPO }}" >> $GITHUB_ENV
-          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-builtin-detector" >> $GITHUB_ENV
+          echo "BUILTIN_IMAGE_NAME=quay.io/trustyai/guardrails-detector-builtin" >> $GITHUB_ENV
       #
       # Run docker commands
       - name: Put expiry date on CI-tagged image
@@ -113,7 +113,7 @@ jobs:
             PR image build completed successfully!
             
             📦 [PR image](https://quay.io/repository/trustyai/guardrails-detector-huggingface-runtime-ci?tab=tags): `quay.io/trustyai/guardrails-detector-huggingface-runtime-ci:${{ github.event.pull_request.head.sha }}`
-            📦 [PR image](https://quay.io/trustyai/guardrails-builtin-detector-ci?tab=tags): `quay.io/trustyai/guardrails-builtin-detector-ci:${{ github.event.pull_request.head.sha }}`
+            📦 [PR image](https://quay.io/trustyai/guardrails-detector-builtin?tab=tags): `quay.io/trustyai/guardrails-detector-builtin-ci:${{ github.event.pull_request.head.sha }}`
       - name: Trivy scan
         uses: aquasecurity/trivy-action@0.28.0
         with:


### PR DESCRIPTION
## Summary by Sourcery

Rename built-in detector Docker image references in the build-and-push workflow to include the "guardrails" prefix for consistency.

Enhancements:
- Update CI log messages to use "guardrails-builtin-detector-ci" image tag.
- Change BUILTIN_IMAGE_NAME environment variable to "quay.io/trustyai/guardrails-builtin-detector(-ci)".
- Update PR image URLs to point to the renamed "guardrails-builtin-detector-ci" repository.