### PR TITLE
Fix broken link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ At the moment, the following detectors are supported:
 
 ## Examples
 
-- Check out [built-in detector examples](docs/builtIn_examples.md) to see how to use the built-in detectors for file type validation and personally identifiable information (PII) detection
+- Check out [built-in detector examples](docs/builtin_examples.md) to see how to use the built-in detectors for file type validation and personally identifiable information (PII) detection
 - Check out [Hugging Face detector examples](docs/hf_examples.md) to see how to use the Hugging Face detectors for detecting toxic content and prompt injection 
 
 ## API


### PR DESCRIPTION
## Summary by Sourcery

Update README to correct the built-in detector examples link and remove the license statement.

Documentation:
- Correct the reference to the built-in detector examples file to use the proper lowercase filename.
- Remove the license description line at the end of the README.