### PR TITLE
Update hf_examples.md to include the container build step

### DIFF
--- a/docs/hf_examples.md
+++ b/docs/hf_examples.md
@@ -99,6 +99,13 @@ export DETECTOR_DIR=$DETECTOR_STORAGE/$DETECTOR_NAME
 huggingface-cli download "$HF_MODEL" --local-dir "$DETECTOR_DIR"
 ```
 
+- Build the image again to include the new model:
+
+```bash
+export HF_IMAGE=hf-detector:latest
+podman build -f detectors/Dockerfile.hf -t $HF_IMAGE detectors
+```
+
 - then spin up the container as before:
 
 ```bash


### PR DESCRIPTION
The prompt injection model guide is missing a step to build the container image again and this step is added.

## Summary by Sourcery

Documentation:
- Add instructions in hf_examples.md to rebuild the container image after downloading the model