### PR TITLE
:bug: fix a bug in `process_sequence_classification` to ensure no 500  when populating detection field of ` ContentAnalysisResponse` for HF models with no `problem_type` in their config

### DIFF
--- a/detectors/common/scheme.py
+++ b/detectors/common/scheme.py
@@ -127,7 +127,7 @@ class ContentAnalysisResponse(BaseModel):
     start: int = Field(example=14)
     end: int = Field(example=26)
     text: str = Field(example="abc@def.com")
-    detection: str = Field(example="Net.EmailAddress")
+    detection: str = Field(default="detection", example="Net.EmailAddress")
     detection_type: str = Field(example="pii")
     score: float = Field(example=0.8)
     evidences: Optional[List[EvidenceObj]] = Field(

--- a/detectors/huggingface/detector.py
+++ b/detectors/huggingface/detector.py
@@ -249,15 +249,16 @@ class Detector:
                     and idx not in all_safe_labels
                     and label not in all_safe_labels
                 ):
+                    detection_value = getattr(self.model.config, "problem_type", None)
                     content_analyses.append(
                         ContentAnalysisResponse(
                             start=0,
                             end=len(text),
-                            detection=getattr(self.model.config, "problem_type", None) or "sequence_classification",
                             detection_type=label,
                             score=prob,
                             text=text,
                             evidences=[],
+                            **({"detection": detection_value} if detection_value is not None else {})
                         )
                     )
         return content_analyses

--- a/detectors/huggingface/detector.py
+++ b/detectors/huggingface/detector.py
@@ -253,7 +253,7 @@ class Detector:
                         ContentAnalysisResponse(
                             start=0,
                             end=len(text),
-                            detection=getattr(self.model.config, "problem_type", "sequence_classification"),
+                            detection=getattr(self.model.config, "problem_type", None) or "sequence_classification",
                             detection_type=label,
                             score=prob,
                             text=text,


### PR DESCRIPTION
For HF models whose config does not contain `problem_type` the `detection` field of `ContentAnalysisResponse` would be  None, which is not allowed by the Pydantic schema.

Fixing this accordingly

## Summary by Sourcery

Bug Fixes:
- Fallback to "sequence_classification" when `problem_type` is missing or None to prevent null detection and 500 errors.