### PR TITLE
Add support for ppc64le compatible guadrails Hugging Face runtime

### DIFF
--- a/detectors/Dockerfile.hf
+++ b/detectors/Dockerfile.hf
@@ -1,19 +1,89 @@
 FROM registry.access.redhat.com/ubi9/ubi-minimal as base
-RUN microdnf update -y && \
-    microdnf install -y --nodocs \
-        python-pip python-devel && \
-    pip install --upgrade --no-cache-dir pip wheel && \
+ENV LD_LIBRARY_PATH=/usr/local/lib64:/usr/local/lib:/usr/lib64:/usr/lib
+ARG TARGETARCH
+
+RUN microdnf update -y                                            && \
+    microdnf install -y --nodocs                                     \
+        python-pip python-devel                                   && \
+    pip install --upgrade --no-cache-dir pip wheel                && \
+    if [ "$TARGETARCH" = "ppc64le" ]; then                           \
+        microdnf install -y --nodocs                                 \
+            git gcc-toolset-13 rust cargo wget unzip              && \
+        pip install --upgrade --no-cache-dir 'cmake<4'             ; \
+    fi                                                            && \
     microdnf clean all
-RUN pip install --no-cache-dir torch
+
+
+RUN if [ "$TARGETARCH" != "ppc64le" ]; then                           \
+        pip install --no-cache-dir torch                            ; \
+    fi
+
+# Buildinf torch for ppc64le
+FROM base as torch-builder
+USER root
+
+ARG MAX_JOBS
+ARG _GLIBCXX_USE_CXX11_ABI=1
+ARG TARGETARCH
+
+ENV TORCH_VERSION=2.6.0
+ENV PATH="$HOME/.cargo/bin:$PATH"
+
+RUN if [ "$TARGETARCH" = "ppc64le" ]; then                                               \
+    source /opt/rh/gcc-toolset-13/enable                                              && \
+    git clone --recursive https://github.com/pytorch/pytorch.git -b v${TORCH_VERSION} && \
+    cd pytorch && pip install -r requirements.txt                                     && \
+    python setup.py develop                                                           && \
+    rm -f dist/torch*+git*whl                                                         && \
+    MAX_JOBS=${MAX_JOBS:-$(nproc)}                                                       \
+    PYTORCH_BUILD_VERSION=${TORCH_VERSION} PYTORCH_BUILD_NUMBER=1 pip wheel . --wheel-dir /tmp/torchwheels/ ;\
+fi
+
+# Building openblas for ppc64le
+FROM base AS openblas-builder
+
+ARG TARGETARCH
+ENV OPENBLAS_VERSION=0.3.30
+
+WORKDIR /root
+
+# Creating a directory for OpenBlas
+RUN mkdir /tmp/openblas
+
+RUN if [ "$TARGETARCH" = "ppc64le" ]; then                                                                                   \
+    source /opt/rh/gcc-toolset-13/enable                                                                                  && \
+    wget https://github.com/OpenMathLib/OpenBLAS/releases/download/v${OPENBLAS_VERSION}/OpenBLAS-${OPENBLAS_VERSION}.zip  && \
+    unzip OpenBLAS-${OPENBLAS_VERSION}.zip -d /tmp/ && mv -T /tmp/OpenBLAS-${OPENBLAS_VERSION} /tmp/openblas              && \
+    cd /tmp/openblas                                                                                                      && \
+    make -j$(nproc) TARGET=POWER9 BINARY=64 USE_OPENMP=1 USE_THREAD=1 NUM_THREADS=120 DYNAMIC_ARCH=1 INTERFACE64=0         ; \
+fi
 
 # FROM icr.io/fm-stack/ubi9-minimal-py39-torch as builder
 FROM base as builder
+ARG TARGETARCH
+
+# Install PyTorch for ppc64le
+RUN --mount=type=bind,from=torch-builder,source=/tmp/,target=/wheels/,ro \
+    if [ "$TARGETARCH" = "ppc64le" ]; then                               \
+        HOME=/root pip install /wheels/torchwheels/*.whl                ;\
+    fi
+
+# Install OpenBlas for ppc64le
+COPY --from=openblas-builder /tmp/openblas/ /openblas
+RUN if [ "$TARGETARCH" = "ppc64le" ]; then                               \
+        PREFIX=/usr/local make -C /openblas install                     ;\
+    fi
 
 COPY ./common/requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 COPY ./huggingface/requirements.txt .
-RUN pip install --no-cache-dir -r requirements.txt
+RUN if [ "$TARGETARCH" = "ppc64le" ]; then                               \
+       source /opt/rh/gcc-toolset-13/enable                            ; \
+    fi                                                                && \
+    pip install --no-cache-dir -r requirements.txt
+
+RUN rm -rf /openblas && rm -rf /wheels
 
 FROM builder
 


### PR DESCRIPTION
Adding support for ppc64le compatible guadrails Hugging Face runtime in multi-arch Dockerfile.hf.

build logs: 
- [x86_logs.txt](https://github.com/user-attachments/files/22078661/x86_logs.txt)
- [ppc64le-logs.txt](https://github.com/user-attachments/files/22078660/ppc64le-logs.txt)

## Summary by Sourcery

Add ppc64le architecture support to the guardrails Hugging Face multi-arch Dockerfile

New Features:
- Enable building the guardrails Hugging Face runtime image on ppc64le
- Integrate ppc64le-specific build steps into the multi-arch Dockerfile.hf

Tests:
- Include build logs for x86_64 and ppc64le to validate the multi-arch build