### PR TITLE
Include Python packages in wheel via package-dir mapping

### DIFF
--- a/detectors/pyproject.toml
+++ b/detectors/pyproject.toml
@@ -50,4 +50,5 @@ requires = ["setuptools>=80.9.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
-packages = []
+package-dir = {"detectors" = "."}
+packages = ["detectors", "detectors.common", "detectors.huggingface", "detectors.llm_judge"]


### PR DESCRIPTION
## Summary

This PR attempts to unblock the following [AIPCC-18688](https://redhat.atlassian.net/browse/AIPCC-18688)

The wheel built from `detectors/pyproject.toml` was empty; it contained only metadata and dependency declarations, no code. This was caused by `packages = []` in the setuptools configuration, which told setuptools to include no Python packages.

The fix uses explicit `package-dir` mapping (`"detectors" = "."`) to produce packages with the correct `detectors.` prefix (`detectors.common`, `detectors.huggingface`, `detectors.llm_judge`), matching the import structure used throughout the codebase (e.g. `from detectors.common.app import ...`).

Note: a plain `[tool.setuptools.packages.find]` with `where = ["."]` was considered but does **not** work here — because `pyproject.toml` lives inside `detectors/`, `find` discovers packages as `common`, `huggingface`, `llm_judge` without the `detectors.` prefix, breaking all imports. The `package-dir` mapping is not applied by `find`; they are independent features in setuptools.




<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package configuration to properly declare all package components and their locations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->